### PR TITLE
Disable notification on by default

### DIFF
--- a/search.js
+++ b/search.js
@@ -98,7 +98,8 @@ module.exports.createOrUpdateCriteria = function(req, res) {
 			console.log(err);
 		} else {
 			updateResult(req.user);
-			enableNotificationIfNotSet(req.user);
+			// TODO: Re-enable when notification system is more customizable.
+			// enableNotificationIfNotSet(req.user);
 		}
 	});
 };


### PR DESCRIPTION
The notification system is not mature enough to be activated by default (yesterday a user received more than 1000 notification emails). Users need to active it themselves if they want to.
